### PR TITLE
Implemented Job Name and Job Location as a schema element

### DIFF
--- a/src/JobComposer.js
+++ b/src/JobComposer.js
@@ -278,27 +278,6 @@ function JobComposer({
                 </button>
               </div>
             </div>
-            {/* Generate button */}
-            {/* <div className="d-flex justify-content-center mb-3">
-              {props.environment.env !== "" && (
-                <input type="button" id="job-preview-button" className="btn btn-primary maroon-button" value="Generate" onClick={props.handlePreview} />
-              )}
-            </div> */}
-
-            {/* <hr className="my-4" style={{ borderColor: '#e1e1e1' }} /> */}
-
-            {/* Show/Hide History button */}
-            {/* <div className="d-flex justify-content-start mb-4">
-              <button
-                className="btn btn-primary maroon-button"
-                onClick={(e) => {
-                  e.preventDefault();
-                  setShowHistory(!showHistory);
-                }}
-              >
-                {showHistory ? 'Hide History' : 'Show History'}
-              </button>
-            </div> */}
 
           </form>          <div style={{ width: '100%', maxWidth: '100%', overflowX: 'auto' }}>
             <SubmissionHistory isExpanded={showHistory} handleRerun={props.handleRerun} handleForm={props.handleForm} />

--- a/src/JobComposer.js
+++ b/src/JobComposer.js
@@ -229,37 +229,6 @@ function JobComposer({
             <div className="row">
               <div className="col-lg-12">
                 <div id="job-content" style={{ maxWidth: '100%' }}>
-                  {/* <Text name="name" id="job-name" label="Job Name" onNameChange={props.sync_job_name} />
-                  <Picker name="location" label="Location" localLabel="Change" defaultLocation={props.runLocation} /> */}
-
-                  {/* <div className="form-group">
-                    <div style={{ display: 'flex', gap: '2rem', flexWrap: 'wrap' }}>
-
-                      {/* {/* Job Name  *
-                      <div style={{ display: 'flex', alignItems: 'center', gap: '1.5rem' }}>
-                        <label htmlFor="job-name" style={{ whiteSpace: 'nowrap' }}>Job Name</label>
-                        <Text name="name" id="job-name" useLabel={false} onNameChange={props.sync_job_name} />
-                      </div>
-
-                      {/* {/* Location  *
-                      <div style={{ display: 'flex', flexGrow: 1, gap: '1.5rem' }}>
-                        <div style={{ display: 'flex', alignItems: 'center' }}>
-                          <label style={{ whiteSpace: 'nowrap' }}>Location</label>
-                        </div>
-                        <div style={{ flex: 1 }}>
-                          <Picker
-                            name="location"
-                            label=""
-                            localLabel="Change"
-                            defaultLocation={props.runLocation}
-                            style={{ width: '100%', alignItems: 'flex-start' }}
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div> */}
-
-
                   <Select
                     key="env_select"
                     name="runtime"

--- a/src/JobComposer.js
+++ b/src/JobComposer.js
@@ -40,9 +40,9 @@ function JobComposer({
 
   const getFormData = () => {
     const paneRefs = multiPaneRef.current?.getPaneRefs();
-    if(!paneRefs) return null;
+    if (!paneRefs) return null;
 
-    if(props.jobStatus === "rerun"){
+    if (props.jobStatus === "rerun") {
       const data = props.rerunInfo;
       const additionalFiles = {};
 
@@ -105,7 +105,7 @@ function JobComposer({
 
       if (props.globalFiles && props.globalFiles.length > 0) {
         props.globalFiles.forEach((file) => {
-            formData.append("files[]", file);
+          formData.append("files[]", file);
         });
       }
 
@@ -118,7 +118,7 @@ function JobComposer({
       setShowConfirmationModal(true);
       return;
     }
-    
+
     if (props.handlePreview) {
       props.handlePreview();
     }
@@ -128,8 +128,8 @@ function JobComposer({
   const handleConfirmOverwrite = () => {
     setShowConfirmationModal(false);
     setIsSplitScreenMinimized(false);
-    reset(); 
-    
+    reset();
+
     if (props.handlePreview) {
       props.handlePreview();
     }
@@ -156,6 +156,11 @@ function JobComposer({
       alert("Error preparing form data.");
       return;
     }
+
+    // if (formData.get("name") === "") {
+    //   alert("Job name is required.");
+    //   return;
+    // }
 
 
     if (isSplitScreenMinimized) {
@@ -186,9 +191,7 @@ function JobComposer({
     <div className="job-composer-container" style={{ width: '100%', maxWidth: '100%', overflowX: 'hidden', height: '100%', maxHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
       {error && <ErrorAlert error={error} onClose={() => setError(null)} />}
       <div className="card shadow" style={{ width: '100%', maxWidth: '100%', display: 'flex', flexDirection: 'column', height: '100%' }}>
-        <div className="card-header">
-          {/* <h6 className="maroon-header">Job Composer</h6> */}
-        </div>
+
         <div className="card-body" style={{ overflowY: 'auto', flex: '1 1 auto' }}>
           <form
             ref={formRef}
@@ -206,8 +209,37 @@ function JobComposer({
             <div className="row">
               <div className="col-lg-12">
                 <div id="job-content" style={{ maxWidth: '100%' }}>
-                  <Text name="name" id="job-name" label="Job Name" onNameChange={props.sync_job_name} />
-                  <Picker name="location" label="Location" localLabel="Change" defaultLocation={props.runLocation} />
+                  {/* <Text name="name" id="job-name" label="Job Name" onNameChange={props.sync_job_name} />
+                  <Picker name="location" label="Location" localLabel="Change" defaultLocation={props.runLocation} /> */}
+
+                  {/* <div className="form-group">
+                    <div style={{ display: 'flex', gap: '2rem', flexWrap: 'wrap' }}>
+
+                      {/* {/* Job Name  *
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '1.5rem' }}>
+                        <label htmlFor="job-name" style={{ whiteSpace: 'nowrap' }}>Job Name</label>
+                        <Text name="name" id="job-name" useLabel={false} onNameChange={props.sync_job_name} />
+                      </div>
+
+                      {/* {/* Location  *
+                      <div style={{ display: 'flex', flexGrow: 1, gap: '1.5rem' }}>
+                        <div style={{ display: 'flex', alignItems: 'center' }}>
+                          <label style={{ whiteSpace: 'nowrap' }}>Location</label>
+                        </div>
+                        <div style={{ flex: 1 }}>
+                          <Picker
+                            name="location"
+                            label=""
+                            localLabel="Change"
+                            defaultLocation={props.runLocation}
+                            style={{ width: '100%', alignItems: 'flex-start' }}
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div> */}
+
+
                   <Select
                     key="env_select"
                     name="runtime"
@@ -224,10 +256,15 @@ function JobComposer({
                     onFileChange={props.handleUploadedFiles}
                     setError={setError}
                     ref={props.composerRef}
+                    sync_job_name={props.sync_job_name}
+                    runLocation={props.runLocation}
+                    setRunLocation={props.setRunLocation}
+                    customRunLocation={props.customRunLocation}
                   />
                 </div>
               </div>
             </div>
+
             <div className="d-flex align-items-center justify-content-between" style={{ marginBottom: '2rem', flexWrap: 'wrap' }}>
               <div className="invisible">
                 <button className="btn btn-primary" style={{ visibility: 'hidden' }}>Balance</button>
@@ -252,13 +289,35 @@ function JobComposer({
                 </button>
               </div>
             </div>
+            {/* Generate button */}
+            {/* <div className="d-flex justify-content-center mb-3">
+              {props.environment.env !== "" && (
+                <input type="button" id="job-preview-button" className="btn btn-primary maroon-button" value="Generate" onClick={props.handlePreview} />
+              )}
+            </div> */}
+
+            {/* <hr className="my-4" style={{ borderColor: '#e1e1e1' }} /> */}
+
+            {/* Show/Hide History button */}
+            {/* <div className="d-flex justify-content-start mb-4">
+              <button
+                className="btn btn-primary maroon-button"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setShowHistory(!showHistory);
+                }}
+              >
+                {showHistory ? 'Hide History' : 'Show History'}
+              </button>
+            </div> */}
+
           </form>          <div style={{ width: '100%', maxWidth: '100%', overflowX: 'auto' }}>
             <SubmissionHistory isExpanded={showHistory} handleRerun={props.handleRerun} handleForm={props.handleForm} />
           </div>
         </div>
         <div className="card-footer">
           <small className="text-muted">
-             Cautions: Job files will overwrite existing files with the same name. The same principle applies for your executable scripts.
+            Cautions: Job files will overwrite existing files with the same name. The same principle applies for your executable scripts.
 
           </small>
         </div>
@@ -287,7 +346,7 @@ function JobComposer({
       />
 
       <EnvironmentModal envModalRef={envModalRef} />
-      
+
       <ConfirmationModal
         isOpen={showConfirmationModal}
         onClose={() => setShowConfirmationModal(false)}

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ export function App() {
   const [runLocation, setRunLocation] = useState(
     defaultRunLocation
   );
-
+  const [baseRunLocation, setBaseRunLocation] = useState(defaultRunLocation)
 
 
   const [environments, setEnvironments] = useState([]);
@@ -64,10 +64,14 @@ export function App() {
       });
   }, []);
 
-  function sync_job_name(name) {
+  function sync_job_name(name, customRunLocation) {
+    // console.log(customRunLocation)
+    const preferredLocation = customRunLocation || baseRunLocation;
+    // console.log("here is the run location " + baseRunLocation)
     setRunLocation(
-      defaultRunLocation + "/" + name
+      preferredLocation + "/" + name
     );
+    setBaseRunLocation(preferredLocation);
   }
 
   useEffect(() => {
@@ -330,10 +334,10 @@ export function App() {
           messages={messages}
           panes={panes}
           setPanes={setPanes}
-	  jobStatus={jobStatus}
-	  globalFiles={globalFiles}
+          jobStatus={jobStatus}
+          globalFiles={globalFiles}
           handlePreview={handlePreview}
-	  rerunInfo={rerunInfo}
+          rerunInfo={rerunInfo}
           handleEnvChange={handleEnvChange}
           handleAddEnv={handleAddEnv}
           handleUploadedFiles={handleUploadedFiles}
@@ -347,6 +351,7 @@ export function App() {
           composerRef={composerRef}
           showSplitScreenModal={showSplitScreenModal}
           setShowSplitScreenModal={setShowSplitScreenModal}
+          setBaseRunLocation={setBaseRunLocation}
         />
         {showRerunModal && (
           <RerunPromptModal

--- a/src/schemaRendering/Composer.js
+++ b/src/schemaRendering/Composer.js
@@ -95,55 +95,55 @@ const Composer = forwardRef((props, ref) => {
   };
 
   // Helper to update visibility and clear hidden field values
-// Helper to update visibility and clear hidden field values
-	//
-const updateVisibilityAndClearHidden = (fields) => {
-  let hasChanged;
-  let newFields = [...fields];
-  
-  do {
-    const result = _updateVisibilityAndClearHidden(newFields, newFields);
-    hasChanged = result.hasChanged;
-    newFields = result.fields;
-  } while(hasChanged);
-  
-  return newFields;
-};
+  // Helper to update visibility and clear hidden field values
+  //
+  const updateVisibilityAndClearHidden = (fields) => {
+    let hasChanged;
+    let newFields = [...fields];
 
-const _updateVisibilityAndClearHidden = (fields, fullFields) => {
-  let hasChanged = false;
-  const newFields = fields.map(field => {
-    const wasVisible = field.isVisible;
-    const isVisible = field.condition
-      ? evaluateCondition(field.condition, fullFields)
-      : true;
+    do {
+      const result = _updateVisibilityAndClearHidden(newFields, newFields);
+      hasChanged = result.hasChanged;
+      newFields = result.fields;
+    } while (hasChanged);
 
-    // Only consider it a change if visibility switches from true to false
-    const wouldChange = wasVisible !== isVisible;
-    
-    const processed = {
-      ...field,
-      isVisible,
-      value: ((isVisible || field.type === "staticText") ? field.value : "")
-    };
+    return newFields;
+  };
 
-    if (Containers.includes(field.type) && field.elements) {
-      const result = _updateVisibilityAndClearHidden(field.elements, fullFields);
-      processed.elements = result.fields;
-      if (result.hasChanged) hasChanged = true;
-    }
+  const _updateVisibilityAndClearHidden = (fields, fullFields) => {
+    let hasChanged = false;
+    const newFields = fields.map(field => {
+      const wasVisible = field.isVisible;
+      const isVisible = field.condition
+        ? evaluateCondition(field.condition, fullFields)
+        : true;
 
-    if (wouldChange) {
-      hasChanged = true;
-    }
+      // Only consider it a change if visibility switches from true to false
+      const wouldChange = wasVisible !== isVisible;
 
-    return processed;
-  });
+      const processed = {
+        ...field,
+        isVisible,
+        value: ((isVisible || field.type === "staticText") ? field.value : "")
+      };
 
-  return { fields: newFields, hasChanged };
-};
-	//
-	//
+      if (Containers.includes(field.type) && field.elements) {
+        const result = _updateVisibilityAndClearHidden(field.elements, fullFields);
+        processed.elements = result.fields;
+        if (result.hasChanged) hasChanged = true;
+      }
+
+      if (wouldChange) {
+        hasChanged = true;
+      }
+
+      return processed;
+    });
+
+    return { fields: newFields, hasChanged };
+  };
+  //
+  //
   // Expose setValues method
   useImperativeHandle(ref, () => ({
     setValues: (dictionary) => {
@@ -197,14 +197,22 @@ const _updateVisibilityAndClearHidden = (fields, fullFields) => {
   };
 
   return (
-  <FormValuesContext.Provider value={contextValue}>
-    <FieldRenderer
-      fields={fields}
-      handleValueChange={handleValueChange}
-      onFileChange={props.onFileChange}
-      setError={props.setError}
-    />
-  </FormValuesContext.Provider>
+    <FormValuesContext.Provider value={contextValue}>
+      <FieldRenderer
+        fields={fields}
+        handleValueChange={handleValueChange}
+        onFileChange={props.onFileChange}
+        setError={props.setError}
+        locationProps={{
+          sync_job_name: props.sync_job_name,
+          runLocation: props.runLocation,
+          setRunLocation: props.setRunLocation,
+          customRunLocation: props.customRunLocation,
+          setBaseRunLocation: props.setBaseRunLocation,
+          // environment: props.environment,
+        }}
+      />
+    </FormValuesContext.Provider>
   );
 });
 

--- a/src/schemaRendering/FieldRenderer.js
+++ b/src/schemaRendering/FieldRenderer.js
@@ -6,7 +6,8 @@ const FieldRenderer = ({
   handleValueChange,
   labelOnTop,
   fieldStyles,
-  setError
+  setError,
+  locationProps = {}
 }) => {
   if (!fields) return null;
   const renderField = useMemo(() => (field) => {
@@ -28,6 +29,7 @@ const FieldRenderer = ({
             labelOnTop={labelOnTop}
             fieldStyles={fieldStyles}
             setError={setError}
+            {...locationProps}
           />
         </div>
       );
@@ -48,6 +50,7 @@ const FieldRenderer = ({
             {...attributes}
             setError={setError}
             onChange={(_, val) => handleValueChange(name, val)}
+            {...locationProps}
           />
         </div>
       );
@@ -61,10 +64,11 @@ const FieldRenderer = ({
           labelOnTop={labelOnTop}
           type={type}
           {...attributes}
+          {...locationProps}
         />
       </div>
     );
-  }, [handleValueChange, fieldStyles, labelOnTop, setError]);
+  }, [handleValueChange, fieldStyles, labelOnTop, setError, locationProps]);
 
   const renderElements = useMemo(() => {
     return fields.map(field => renderField(field)).filter(Boolean);
@@ -77,7 +81,9 @@ const FieldRenderer = ({
 const areEqual = (prevProps, nextProps) => {
   return (
     prevProps.fields === nextProps.fields &&
-    prevProps.handleValueChange === nextProps.handleValueChange
+    // prevProps.handleValueChange === nextProps.handleValueChange
+    prevProps.handleValueChange === nextProps.handleValueChange &&
+    prevProps.locationProps === nextProps.locationProps
   );
 };
 

--- a/src/schemaRendering/schemaElements/Checkbox.js
+++ b/src/schemaRendering/schemaElements/Checkbox.js
@@ -26,10 +26,10 @@ function Checkbox(props) {
   const [isChecked, setIsChecked] = useState(false);
   const defaultValue = props.value || "Yes";  // Default to "Yes" if no value provided
   const [checkboxValue, setCheckboxValue] = useState(defaultValue);
-  
+
   useEffect(() => {
-    if(props.value !== ""){
-    	setCheckboxValue(props.value);
+    if (props.value !== "") {
+      setCheckboxValue(props.value);
     }
     setIsChecked(props.value !== "");
   }, [props.value]);
@@ -42,20 +42,23 @@ function Checkbox(props) {
 
   return (
     <FormElementWrapper
-      labelOnTop={props.labelOnTop}
+      labelOnTop={true}
       name={props.name}
       label={props.label}
       help={props.help}
     >
-        <input
-          type="checkbox"
-          name={props.name}
-          id={props.id}
-          value={checkboxValue}
-          checked={isChecked}
-          className="form-control move-left"
-          onChange={handleValueChange}
-        />
+      <input
+        type="checkbox"
+        style={{
+          width: "20px", marginTop: "auto"
+        }}
+        name={props.name}
+        id={props.id}
+        value={checkboxValue}
+        checked={isChecked}
+        className="form-control move-left"
+        onChange={handleValueChange}
+      />
     </FormElementWrapper>
   );
 }

--- a/src/schemaRendering/schemaElements/JobNameLocation.js
+++ b/src/schemaRendering/schemaElements/JobNameLocation.js
@@ -1,0 +1,99 @@
+import React, { useEffect } from "react";
+import FormElementWrapper from "../utils/FormElementWrapper";
+import Text from "../schemaElements/Text";
+import Picker from "../schemaElements/Picker";
+
+/**
+ * JobNameLocation: composite control for job "name" + "location"
+ * Writes to engine keys: "name" and "location"
+ */
+export default function JobNameLocation({
+    // schema-configurable
+    showName = true,
+    showLocation = true,
+    disableJobNameChange,
+    disableJobLocationChange,
+    help,
+    labelOnTop = true,
+    customJobName,
+    customJobLocation,
+    label,
+
+    // pass-through from Composer/FieldRenderer
+    sync_job_name,          // e.g., props.sync_job_name
+    runLocation,       // e.g., props.runLocation
+    setRunLocation,
+    setBaseRunLocation,
+    onChange,              // forwarded from FieldRenderer (handleValueChange wrapper)
+    setError,              // optional; safe to accept/ignore
+    ...rest                // future-proof
+}) {
+    // derive unique ids to avoid collisions
+    // useEffect(() => {
+    //     console.groupCollapsed("11111 [Picker] sanity");
+    //     console.log("typeof setBaseRunLocation:", typeof setBaseRunLocation);
+    //     console.groupEnd();
+    // }, [setBaseRunLocation]);
+
+    useEffect(() => {
+        if (customJobLocation) {
+            setRunLocation?.(customJobLocation);
+            // onChange?.("location", customJobLocation);
+        }
+        if (customJobName) {
+            sync_job_name?.(customJobName, customJobLocation);
+            // onChange?.("name", customJobName);
+        }
+    }, []);
+
+    return (
+        <FormElementWrapper
+            labelOnTop={labelOnTop}
+            name={"name_location"}
+            label={label}
+            help={help}
+        >
+            <div className="form-group">
+                <div style={{ display: 'flex', gap: '2rem', flexWrap: 'wrap' }}>
+                    {showName && (
+                        <div style={{ display: 'flex', alignItems: 'center', gap: '1.5rem' }}>
+                            <label htmlFor="job-name" style={{ whiteSpace: 'nowrap' }}>Job Name</label>
+                            <Text
+                                name={"name"}
+                                id={"job-name"}
+                                label=""
+                                value={customJobName || ""}
+                                useLabel={false}              // suppress inner label; we render our own
+                                onNameChange={sync_job_name}   // mirrors previous inline behavior
+                                onChange={onChange}
+                                placeholder="Drona ID"
+                                disableChange={disableJobNameChange}
+
+                            />
+                        </div>
+                    )}
+
+                    {showLocation && (
+                        <div style={{ display: 'flex', flexGrow: 1, gap: '1.5rem' }}>
+                            <div style={{ display: 'flex', alignItems: 'center' }}>
+                                <label style={{ whiteSpace: 'nowrap' }}>Location</label>
+                            </div>
+                            <div style={{ flex: 1 }}>
+                                <Picker
+                                    name={"location"}
+                                    useLabel={false}
+                                    localLabel="Change"
+                                    defaultLocation={runLocation}
+                                    onChange={onChange}          // keep renderer state/hooks consistent
+                                    setBaseRunLocation={setBaseRunLocation}
+                                    style={{ width: "100%", alignItems: "flex-start" }}
+                                    disableChange={disableJobLocationChange}
+                                />
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </FormElementWrapper>
+    );
+}

--- a/src/schemaRendering/schemaElements/Picker.js
+++ b/src/schemaRendering/schemaElements/Picker.js
@@ -77,7 +77,7 @@ function Picker(props) {
       }
     }
   }, [uploadedFiles]);
-  
+
   useEffect(() => {
     let url = document.dashboard_url + "/jobs/composer/mainpaths";
     const searchParams = new URLSearchParams();
@@ -105,8 +105,8 @@ function Picker(props) {
     setCurrentPath(fullPath);
     fetch(
       document.dashboard_url +
-        "/jobs/composer/subdirectories?path=" +
-        encodeURIComponent(fullPath),
+      "/jobs/composer/subdirectories?path=" +
+      encodeURIComponent(fullPath),
       {
         method: "GET",
         headers: {
@@ -134,8 +134,8 @@ function Picker(props) {
     setCurrentPath(fullPath);
     fetch(
       document.dashboard_url +
-        "/jobs/composer/subdirectories?path=" +
-        encodeURIComponent(fullPath),
+      "/jobs/composer/subdirectories?path=" +
+      encodeURIComponent(fullPath),
       {
         method: "GET",
         headers: {
@@ -170,8 +170,8 @@ function Picker(props) {
     setCurrentPath(newPath);
     fetch(
       document.dashboard_url +
-        "/jobs/composer/subdirectories?path=" +
-        encodeURIComponent(newPath),
+      "/jobs/composer/subdirectories?path=" +
+      encodeURIComponent(newPath),
       {
         method: "GET",
         headers: {
@@ -243,8 +243,8 @@ function Picker(props) {
 
     remoteInput.current.click();
   }
-    
-  
+
+
   // Returns false if showFiles is undefined, returns true if showFiles is boolean and true or is a string its toLowerCase is "true"
   const isShowFiles = Boolean(props.showFiles) && props.showFiles.toString().toLowerCase() === "true";
   const showRemoteLabel = props.remoteLabel ? true : false;
@@ -256,18 +256,10 @@ function Picker(props) {
         name={props.name}
         label={props.label}
         help={props.help}
+        useLabel={props.useLabel}
       >
         <div style={{ display: "flex", gap: "0.5rem" }}>
-          {showRemoteLabel && (
-            <button
-              type="button"
-              className="btn btn-primary maroon-button"
-              style={{ marginRight: "2px" }}
-              onClick={handleRemoteClick}
-            >
-              {props.remoteLabel}
-            </button>
-          )}
+
           <input
             type="file"
             style={{ display: "none" }}
@@ -275,15 +267,6 @@ function Picker(props) {
             ref={remoteInput}
             onChange={(e) => handleFileChange(e.target.files)}
           />
-          <button
-            type="button"
-            className="btn btn-primary maroon-button"
-            data-toggle="modal"
-            data-target={"#local-file-picker-modal-" + props.name}
-            style={{ marginRight: "2px" }}
-          >
-            {props.localLabel}
-          </button>
           <input
             type="text"
             name={props.name}
@@ -294,8 +277,27 @@ function Picker(props) {
             onChange={handleValueChange}
             ref={inputRef}
           />
+          {showRemoteLabel && (
+            <button
+              type="button"
+              className="btn btn-primary maroon-button"
+              style={{ marginRight: "2px" }}
+              onClick={handleRemoteClick}
+            >
+              {props.remoteLabel}
+            </button>
+          )}
+          <button
+            type="button"
+            className="btn btn-primary maroon-button"
+            data-toggle="modal"
+            data-target={"#local-file-picker-modal-" + props.name}
+            style={{ marginRight: "2px" }}
+          >
+            {props.localLabel}
+          </button>
         </div>
-      </FormElementWrapper> 
+      </FormElementWrapper>
       <div
         className="modal fade"
         id={"local-file-picker-modal-" + props.name}
@@ -308,7 +310,7 @@ function Picker(props) {
           <div className="modal-content">
             <div className="modal-header">
               <h5 className="modal-title" id="exampleModalLabel">
-                {props.label} 
+                {props.label}
               </h5>
               <button
                 type="button"
@@ -398,7 +400,7 @@ function Picker(props) {
           </div>
         </div>
       </div>
-    </div>
+    </div >
   );
 }
 

--- a/src/schemaRendering/schemaElements/Picker.js
+++ b/src/schemaRendering/schemaElements/Picker.js
@@ -259,24 +259,6 @@ function Picker(props) {
         useLabel={props.useLabel}
       >
         <div style={{ display: "flex", gap: "0.5rem" }}>
-
-          <input
-            type="file"
-            style={{ display: "none" }}
-            multiple
-            ref={remoteInput}
-            onChange={(e) => handleFileChange(e.target.files)}
-          />
-          <input
-            type="text"
-            name={props.name}
-            id={props.id}
-            // value={value}
-            value={value}
-            className="form-control"
-            onChange={handleValueChange}
-            ref={inputRef}
-          />
           {showRemoteLabel && (
             <button
               type="button"
@@ -287,6 +269,13 @@ function Picker(props) {
               {props.remoteLabel}
             </button>
           )}
+          <input
+            type="file"
+            style={{ display: "none" }}
+            multiple
+            ref={remoteInput}
+            onChange={(e) => handleFileChange(e.target.files)}
+          />
           <button
             type="button"
             className="btn btn-primary maroon-button"
@@ -296,6 +285,16 @@ function Picker(props) {
           >
             {props.localLabel}
           </button>
+          <input
+            type="text"
+            name={props.name}
+            id={props.id}
+            // value={value}
+            value={value}
+            className="form-control"
+            onChange={handleValueChange}
+            ref={inputRef}
+          />
         </div>
       </FormElementWrapper>
       <div
@@ -400,7 +399,7 @@ function Picker(props) {
           </div>
         </div>
       </div>
-    </div >
+    </div>
   );
 }
 

--- a/src/schemaRendering/schemaElements/Text.js
+++ b/src/schemaRendering/schemaElements/Text.js
@@ -23,14 +23,21 @@
 
 import React, { useState, useEffect } from "react";
 import FormElementWrapper from "../utils/FormElementWrapper";
+import { FormValuesContext } from '../FormValuesContext';
+import { useContext } from "react";
 
 function Text(props) {
   const [value, setValue] = useState(props.value || "");
+  const { values: formValues } = useContext(FormValuesContext);
 
+  // console.log(formValues)
   function handleValueChange(event) {
     setValue(event.target.value);
     if (props.onChange) props.onChange(props.index, event.target.value);
-    if (props.onNameChange) props.onNameChange(event.target.value);
+    if (props.onNameChange) {
+
+      props.onNameChange(event.target.value);
+    }
   }
   useEffect(() => {
     setValue(props.value || "");
@@ -41,6 +48,7 @@ function Text(props) {
       name={props.name}
       label={props.label}
       help={props.help}
+      useLabel={props.useLabel}
     >
       <input
         type="text"
@@ -49,7 +57,9 @@ function Text(props) {
         value={value}
         placeholder={props.placeholder}
         className="form-control"
-        onChange={handleValueChange}
+        onChange={props.disableChange ? undefined : handleValueChange}
+        disabled={props.disableChange}
+
       />
     </FormElementWrapper>
   );

--- a/src/schemaRendering/schemaElements/index.js
+++ b/src/schemaRendering/schemaElements/index.js
@@ -17,6 +17,7 @@ import StaticText from "./StaticText";
 import Hidden from "./Hidden";
 import AutocompleteSelect from "./AutocompleteSelect";
 import DragDropContainer from "./DragDropContainer";
+import JobNameLocation from "./JobNameLocation";
 
 
 export {
@@ -39,29 +40,31 @@ export {
 	AutocompleteSelect,
 	CollapsibleRowContainer,
 	CollapsibleColContainer,
-	DragDropContainer
+	DragDropContainer,
+	JobNameLocation
 }
 
 export const componentsMap = {
-  text: Text,
-  select: Select,
-  number: Number,
-  checkbox: Checkbox,
-  rowContainer: RowContainer,
-  radioGroup: RadioGroup,
-  picker: Picker,
-  uploader: Uploader,
-  time: Time,
-  module: Module,
-  unit: Unit,
-  dynamicSelect: DynamicSelect,
-  textarea: TextArea,
-  staticText: StaticText,
-  hidden: Hidden,
-  autocompleteSelect: AutocompleteSelect,
-  collapsibleRowContainer: CollapsibleRowContainer,
-  collapsibleColContainer: CollapsibleColContainer,
-  dragDropContainer: DragDropContainer
+	text: Text,
+	select: Select,
+	number: Number,
+	checkbox: Checkbox,
+	rowContainer: RowContainer,
+	radioGroup: RadioGroup,
+	picker: Picker,
+	uploader: Uploader,
+	time: Time,
+	module: Module,
+	unit: Unit,
+	dynamicSelect: DynamicSelect,
+	textarea: TextArea,
+	staticText: StaticText,
+	autocompleteSelect: AutocompleteSelect,
+	collapsibleRowContainer: CollapsibleRowContainer,
+	collapsibleColContainer: CollapsibleColContainer,
+	dragDropContainer: DragDropContainer,
+	jobNameLocation: JobNameLocation
+
 };
 
 export const Containers = ["rowContainer", "collapsibleRowContainer", "collapsibleColContainer", "dragDropContainer"];

--- a/src/schemaRendering/utils/FormElementWrapper.js
+++ b/src/schemaRendering/utils/FormElementWrapper.js
@@ -1,26 +1,26 @@
 import React from "react";
 import Label from "./Label";
 
-const FormElementWrapper = ({ labelOnTop, name, label, help, children, useLabel=true }) => {
-return (
+const FormElementWrapper = ({ labelOnTop, name, label, help, children, useLabel = true }) => {
+  return (
     <div className="form-group">
 
-      {useLabel ? 
-      labelOnTop ? (
-        // Label on top of the input field
-        <>
-          <Label labelOnTop name={name} label={label} help={help} />
+      {useLabel ?
+        labelOnTop ? (
+          // Label on top of the input field
+          <>
+            <Label labelOnTop name={name} label={label} help={help} />
+            <div>{children}</div>
+          </>
+        ) : (
+          // Label beside the input field (default)
+          <div className="row">
+            <Label name={name} label={label} help={help} />
+            <div className="col-lg-9">{children}</div>
+          </div>
+        ) : (
           <div>{children}</div>
-        </>
-      ) : (
-        // Label beside the input field (default)
-        <div className="row">
-          <Label name={name} label={label} help={help} />
-          <div className="col-lg-9">{children}</div>
-        </div>
-      ) : (
-        <div>{children}</div>
-      )}
+        )}
     </div>
   );
 };


### PR DESCRIPTION
Closes #143  
Closes #141  

**Changes included:**
- Implemented **JobNameLocation** so it renders dynamically according to `schema.json`.
- Changed the size of the checkbox to be smaller.

**Usage Example:**
```json
"runDestination": {
  "type": "jobNameLocation",
  "help": "Optional. Leave blank to use defaults. If empty, the engine will assign a job ID and staging path automatically.",
  "customJobName": "job1",
  "customJobLocation": "scatch/dsa/dsa/d/sad/sa/dsa/d",
  "showName": true,
  "showLocation": true,
  "disableJobNameChange": true,
  "disableJobLocationChange": true
}
