### PR TITLE
Default name/location when job name/location element is missing

### DIFF
--- a/src/JobComposer.js
+++ b/src/JobComposer.js
@@ -135,10 +135,10 @@ function JobComposer({
       }
 
       const location = formData.get("location");
-      console.log("LOCATION1: ", location)
+      // console.log("LOCATION1: ", location)
       if (!location) {
         if (props.runLocation) formData.set("location", props.runLocation);
-        console.log("LOCATION2: ", props.runLocation)
+        // console.log("LOCATION2: ", props.runLocation)
       }
 
       return formData;

--- a/src/index.js
+++ b/src/index.js
@@ -312,11 +312,11 @@ export function App() {
     }
 
     const location = formData.get("location");
-    console.log("LOCATION1: ", location)
+    // console.log("LOCATION1: ", location)
 
     if (!location) {
       if (runLocation) formData.set("location", runLocation);
-      console.log("LOCATION2: ", runLocation)
+      // console.log("LOCATION2: ", runLocation)
     }
 
 
@@ -334,10 +334,10 @@ export function App() {
 
     const action = document.dashboard_url + "/jobs/composer/preview";
 
-    console.log("FormData: ")
-    for (const [key, value] of formData.entries()) {
-      console.log(key, value);
-    }
+    // console.log("FormData: ")
+    // for (const [key, value] of formData.entries()) {
+    //   console.log(key, value);
+    // }
 
     preview_job(action, formData, function (error, jobScript) {
       if (error) {


### PR DESCRIPTION
- If `name`/`location` form fields is empty then apply defaults value.
- Default `name` to the workflow id.
- Default `location` to `<drona_root>/runs/<workflow_id>` when the schema has no job name/location elements.