### PR TITLE
Disable button right after pressing submit

### DIFF
--- a/src/JobComposer.js
+++ b/src/JobComposer.js
@@ -34,6 +34,7 @@ function JobComposer({
   const [showRequiredFieldsModal, setShowRequiredFieldsModal] = useState(false);
   const [missingRequiredFields, setMissingRequiredFields] = useState([]);
   const [configBlocked, setConfigBlocked] = useState(false);
+  const [hasSubmittedCurrentPreview, setHasSubmittedCurrentPreview] = useState(false);
 
   const [workflowMode, setWorkflowmode] = useState(null)
 
@@ -49,6 +50,11 @@ function JobComposer({
   } = useJobSocket();
 
   const isJobRunning = status === 'submitting' || status === 'running';
+  const isSubmitDisabled = hasSubmittedCurrentPreview || isJobRunning;
+
+  useEffect(() => {
+    console.log("hasSubmittedCurrentPreview changed ->", hasSubmittedCurrentPreview);
+  }, [hasSubmittedCurrentPreview]);
 
   const getFormData = () => {
     const paneRefs = multiPaneRef.current?.getPaneRefs();
@@ -174,6 +180,7 @@ function JobComposer({
     setShowConfirmationModal(false);
     setIsSplitScreenMinimized(false);
     reset();
+    setHasSubmittedCurrentPreview(false);
     if (setDronaJobId && dronaJobId) {
       setDronaJobId(dronaJobId + "*");
       setPendingNewPreview(true);
@@ -195,6 +202,10 @@ function JobComposer({
     e.preventDefault();
     if (!props.environment || !props.environment.env) {
       setError("Please choose an environment before submitting.");
+      return;
+    }
+
+    if (hasSubmittedCurrentPreview) {
       return;
     }
 
@@ -228,6 +239,7 @@ function JobComposer({
 
     // Start the job submission - modal stays open to show streaming
     const action = formRef.current.getAttribute("action");
+    setHasSubmittedCurrentPreview(true);
     submitJob(action, formData);
   };
 
@@ -235,6 +247,7 @@ function JobComposer({
     setShowSplitScreenModal(false);
     setIsSplitScreenMinimized(false);
     reset();
+    setHasSubmittedCurrentPreview(false);
     if (setDronaJobId && dronaJobId) {
       setDronaJobId(dronaJobId + "*");
     }
@@ -362,6 +375,7 @@ function JobComposer({
         onSubmit={handleSubmit}
         // Job control
         isJobRunning={isJobRunning}
+        isSubmitDisabled={isSubmitDisabled}
       />
 
       <EnvironmentModal envModalRef={envModalRef} />

--- a/src/SplitScreenModal.js
+++ b/src/SplitScreenModal.js
@@ -56,7 +56,7 @@ const ResizeHandle = ({ isResizing, onMouseDown, styles }) => {
   );
 };
 
-const ModalFooter = ({ onClose, styles }) => {
+const ModalFooter = ({ onClose, styles, isSubmitDisabled }) => {
   return (
     <div style={styles.footer}>
       <div style={styles.footerTip}>
@@ -67,9 +67,22 @@ const ModalFooter = ({ onClose, styles }) => {
         <button
           type="submit"
           form="slurm-config-form"
-          style={styles.button.primary}
-          onMouseOver={(e) => e.target.style.backgroundColor = '#500000'}
-          onMouseOut={(e) => e.target.style.backgroundColor = 'maroon'}
+          disabled={isSubmitDisabled}
+          style={{
+            ...styles.button.primary,
+            opacity: isSubmitDisabled ? 0.65 : 1,
+            cursor: isSubmitDisabled ? 'not-allowed' : 'pointer'
+          }}
+          onMouseOver={(e) => {
+            if (!isSubmitDisabled) {
+              e.target.style.backgroundColor = '#500000';
+            }
+          }}
+          onMouseOut={(e) => {
+            if (!isSubmitDisabled) {
+              e.target.style.backgroundColor = 'maroon';
+            }
+          }}
         >
           Submit Job
         </button>
@@ -114,7 +127,8 @@ const SplitScreenModal = ({
   onSubmit,
   onMinimize: onMinimizeCallback,
   onExpand: onExpandCallback,
-  forceMinimized = null
+  forceMinimized = null,
+  isSubmitDisabled = false
 }) => {
   const contentRef = useRef(null);
   const modalRef = useRef(null);
@@ -196,7 +210,7 @@ const SplitScreenModal = ({
           />
         </div>
 
-        <ModalFooter onClose={onClose} styles={styles} />
+        <ModalFooter onClose={onClose} styles={styles} isSubmitDisabled={isSubmitDisabled} />
       </div>
     </div>
   );


### PR DESCRIPTION
- Disabled the `Submit Job` button after the first submit
- Kept the button disabled while the preview is minimized/restored
- Reset the submit lock only when the preview is closed or a new preview is created