### PR TITLE
fix: harden Drona directory configuration and migration

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ from flask import Flask, render_template, redirect, jsonify, current_app
 from flask_cors import CORS
 from views.job_composer import job_composer
 from views import socket_handler
-from views.utils import get_drona_dir, get_drona_root
+from views.utils import get_current_drona_dir, get_drona_root
 import yaml
 import os
 
@@ -30,11 +30,11 @@ app.config.update(config)
 app.config['user'] = os.environ['USER']
 app.config['drona_root'] = get_drona_root()
 
-dd = get_drona_dir()    
-if dd["ok"]:
-    app.config['drona_dir'] = dd["drona_dir"]
-else:
-    app.config["drona_dir"] = None
+
+@app.context_processor
+def inject_user_config():
+    """Read user-scoped configuration for every rendered page request."""
+    return {"current_drona_dir": get_current_drona_dir()}
 
 app.register_blueprint(job_composer, url_prefix="/jobs/composer")
 

--- a/machine_driver_scripts/engine.py
+++ b/machine_driver_scripts/engine.py
@@ -1,5 +1,6 @@
 import json
 import re
+import shlex
 import argparse
 import ast
 import shutil
@@ -287,6 +288,13 @@ class Engine():
         
             # Remove variable tags
             value = re.sub(r'<var>(.*?)\n*</var>', r'\1', value, flags=re.DOTALL)
+
+            # flocation is substituted into shell templates (normally `cd
+            # [flocation]`). Quote it once in the engine so imported workflows
+            # remain safe when a configured or job directory contains spaces or
+            # shell metacharacters.
+            if key == "flocation":
+                value = shlex.quote(value)
         
         
             map[key] = value
@@ -628,4 +636,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/src/ConfigGate.js
+++ b/src/ConfigGate.js
@@ -10,39 +10,75 @@ export default function ConfigGate(props) {
   const [notice, setNotice] = useState(null);
   const [showNotice, setShowNotice] = useState(false);
 
+  const migrationNoticeKey = "dronaMigrationNotice";
+
 
   useEffect(() => {
+    props.onStatusChange(true);
+
     (async () => {
       try {
         if (!window.CONFIG_STATUS_URL) {
           console.error("ConfigGate: CONFIG_STATUS_URL is not defined on window");
           setAction("error");
           setReason("Configuration status URL not defined.");
-          setLoading(false);
           return;
         }
         
         const r = await fetch(window.CONFIG_STATUS_URL, { credentials: "same-origin" });
         const j = await r.json();
+
+        if (!r.ok) {
+          throw new Error(j.reason || `Configuration status failed (${r.status})`);
+        }
+
         setAction(j.action);
 
+        if (j.action === "migrated") {
+          if (j.notice) {
+            try {
+              window.sessionStorage.setItem(migrationNoticeKey, j.notice);
+            } catch (storageError) {
+              console.warn("ConfigGate: could not preserve migration notice", storageError);
+            }
+          }
 
-        if (j.action === "migrated" && j.notice) {
-            setNotice(j.notice);      
-            setShowNotice(true);
+          // The current HTML was rendered before migration and therefore has a
+          // null/stale document.drona_dir. Render it again from the new config.
+          window.location.reload();
+          return;
         }
+
+        if (j.action === "ok") {
+          try {
+            const savedNotice = window.sessionStorage.getItem(migrationNoticeKey);
+            if (savedNotice) {
+              setNotice(savedNotice);
+              setShowNotice(true);
+              window.sessionStorage.removeItem(migrationNoticeKey);
+            }
+          } catch (storageError) {
+            console.warn("ConfigGate: could not restore migration notice", storageError);
+          }
+        }
+
         if (j.action === "select_needed") {
           setReason(j.reason || "Configuration not found.");
           setCurrentDir("");
           props.onStatusChange(true);
-        } else {
+        } else if (j.action === "ok") {
           setCurrentDir(j.drona_dir || "");
           props.onStatusChange(false);
+        } else {
+          setAction("error");
+          setReason(j.reason || "Configuration could not be verified.");
+          props.onStatusChange(true);
         }
       } catch (e) {
         console.error("ConfigGate: status fetch failed:", e);
         setAction("error");
-        setReason("Failed to check configuration status.");
+        setReason(e.message || "Failed to check configuration status.");
+        props.onStatusChange(true);
       } finally {
         setLoading(false);
       }
@@ -51,6 +87,7 @@ export default function ConfigGate(props) {
 
   async function handleDronaPathChange(_index, selectedPath) {
       if (!selectedPath) { alert("No directory was selected."); return; }
+      if (!window.CONFIG_SAVE_URL) { alert("Configuration save URL not defined."); return; }
       const resp = await fetch(window.CONFIG_SAVE_URL, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -86,9 +123,26 @@ export default function ConfigGate(props) {
       </div>
     )}
 
+    {!loading && action === "error" && (
+      <div className="alert alert-danger" role="alert" style={{ marginBottom: 12 }}>
+        <strong>Configuration error:</strong> {reason || "Configuration could not be verified."}
+      </div>
+    )}
+
     {loading || action !== "select_needed" ? null : (
       <div className="alert alert-warning" style={{ marginBottom: 12 }}>
-        <div style={{ fontWeight: 600, marginBottom: 6 }}>Select directory where Drona will store workflow data and environments.</div>
+        {reason && (
+          <div role="status" style={{ marginBottom: 10 }}>
+            {reason}
+          </div>
+        )}
+        <div style={{ fontWeight: 600, marginBottom: 6 }}>
+          Choose where Drona should create its <code>drona_wfe</code> folder.
+        </div>
+        <div style={{ marginBottom: 10 }}>
+          Selecting a parent directory creates or reuses <code>drona_wfe</code> inside it.
+          Selecting an existing folder named <code>drona_wfe</code> uses that folder directly.
+        </div>
 
         <div className="drona-dir-picker">
           <Picker

--- a/src/JobComposer.js
+++ b/src/JobComposer.js
@@ -36,7 +36,7 @@ function JobComposer({
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
   const [showRequiredFieldsModal, setShowRequiredFieldsModal] = useState(false);
   const [missingRequiredFields, setMissingRequiredFields] = useState([]);
-  const [configBlocked, setConfigBlocked] = useState(false);
+  const [configBlocked, setConfigBlocked] = useState(true);
   const [hasSubmittedCurrentPreview, setHasSubmittedCurrentPreview] = useState(false);
   const [showEnvironmentFilmstrip, setShowEnvironmentFilmstrip] = useState(true);
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -107,7 +107,7 @@
            document.file_app_url = "{{ config.file_app_url }}";
            document.file_editor_url = "{{ config.file_editor_url }}";
            document.user = "{{ config.user }}";
-           document.drona_dir = {{ config.drona_dir|tojson }}
+           document.drona_dir = {{ current_drona_dir|tojson }};
 
         window.CONFIG_STATUS_URL = "{{ url_for('job_composer.config_status') }}";
         window.CONFIG_SAVE_URL = "{{ url_for('job_composer.config_save') }}";

--- a/templates/layout_no_banner.html
+++ b/templates/layout_no_banner.html
@@ -70,9 +70,12 @@
         document.file_app_url = "{{ config.file_app_url }}";
         document.file_editor_url = "{{ config.file_editor_url }}";
         document.user = "{{ config.user }}";
-	document.drona_dir = "{{ config.drona_dir }}";
+	document.drona_dir = {{ current_drona_dir|tojson }};
 	document.drona_root = "{{ config.drona_root }}";
 	document.module_db_root = "{{ config.module_db_root or '' }}";
+
+        window.CONFIG_STATUS_URL = "{{ url_for('job_composer.config_status') }}";
+        window.CONFIG_SAVE_URL = "{{ url_for('job_composer.config_save') }}";
       </script>
 
       <!-- <div id="main-container" class="container" role="main"> -->

--- a/views/config_routes.py
+++ b/views/config_routes.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, render_template
 from flask import jsonify, request, current_app
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 import os, json
 
 from .utils import get_drona_config, probe_and_autofix_config, _write_config_json_atomically, maybe_migrate_legacy_history
@@ -25,31 +26,40 @@ def config_save():
     if not request.is_json:
         return jsonify({"status":"error","message":"Request must be JSON"}), 400
 
-    base = (request.get_json(silent=True) or {}).get("drona_dir", "").strip()
+    base = (request.get_json(silent=True) or {}).get("drona_dir", "")
+    if not isinstance(base, str):
+        return jsonify({"status":"error","message":"'drona_dir' must be a string"}), 400
+    base = base.strip()
     if not base:
         return jsonify({"status":"error","message":"Missing 'drona_dir'"}), 400
 
-    base_path = Path(base).expanduser().resolve()
+    # Preserve a selected symlink's name so an existing drona_wfe alias does not
+    # become drona_composer/drona_wfe after resolution.
+    base_path = Path(os.path.abspath(Path(base).expanduser()))
     if not base_path.exists() or not base_path.is_dir():
         return jsonify({"status":"error","message":f"Directory does not exist: {base_path}"}), 400
 
-    target = base_path / "drona_wfe"
+    target = base_path if base_path.name == "drona_wfe" else base_path / "drona_wfe"
     try:
         target.mkdir(parents=True, exist_ok=True)
+        # Prove write access using the same kind of operation Drona needs later.
+        with NamedTemporaryFile(prefix=".drona-write-test-", dir=target):
+            pass
+    except OSError as e:
+        return jsonify({"status":"error","message":f"Drona directory is not writable: {target}: {e}"}), 400
+
+    try:
         _write_config_json_atomically(str(target))
     except Exception as e:
-        return jsonify({"status":"error","message":f"Failed to create/save: {e}"}), 500
+        return jsonify({"status":"error","message":f"Failed to save configuration: {e}"}), 500
 
     return jsonify({
         "status":"ok",
         "drona_dir": str(target),
-        "message": f"Created directory '{target}'. Configuration saved."
+        "message": f"Drona will store its data in '{target}'."
     }), 200
 
 def register_config_routes(blueprint):
     """Register all config-related routes to the blueprint"""
     blueprint.route('/api/config/status', methods=['GET'])(config_status)
     blueprint.route('/api/config/save', methods=['POST'])(config_save)
-
-
-

--- a/views/job_routes.py
+++ b/views/job_routes.py
@@ -1,6 +1,7 @@
 from flask import Response, stream_with_context, Blueprint, send_file, render_template, request, jsonify
 import os
 import re
+import shlex
 import subprocess
 import threading
 import uuid
@@ -12,6 +13,11 @@ from .file_utils import save_file
 
 logger = Logger()
 socketio = None  # Will be initialized when passed from main app
+
+
+def build_driver_command(driver_script_path):
+    """Build a shell command without allowing the script path to be split."""
+    return f"bash {shlex.quote(driver_script_path)}"
 
 def extract_job_id(submit_response):
     """Extract job ID from the sbatch submission response"""
@@ -65,7 +71,7 @@ def submit_job_route():
     bash_script_path = engine.generate_script(params)
     driver_script_path = engine.generate_driver_script(params)
 
-    bash_cmd = f"bash {driver_script_path}"
+    bash_cmd = build_driver_command(driver_script_path)
 
     history_manager = JobHistoryManager()
     job_record = history_manager.save_job(

--- a/views/socket_handler.py
+++ b/views/socket_handler.py
@@ -42,18 +42,18 @@ import subprocess
 from datetime import datetime
 
 # Job configuration
-JOB_ID = "{drona_job_id}"
-JOBS_DIR = "{jobs_dir}"
+JOB_ID = {drona_job_id!r}
+JOBS_DIR = {jobs_dir!r}
 STATUS_FILE = os.path.join(JOBS_DIR, f"{{JOB_ID}}.json")
 OUTPUT_FILE = os.path.join(JOBS_DIR, f"{{JOB_ID}}.out")
-BASH_CMD = """{bash_cmd}"""
+BASH_CMD = {bash_cmd!r}
 
 def update_status(status, exit_code=None):
     """Update job status file"""
     status_data = {{
         "job_id": JOB_ID,
         "status": status,
-        "created_at": "{datetime.now().isoformat()}",
+            "created_at": {datetime.now().isoformat()!r},
         "updated_at": datetime.now().isoformat()
     }}
     if exit_code is not None:
@@ -88,11 +88,11 @@ def run_command_with_pty():
             'PYTHONUNBUFFERED': '1'
         }})
         
-        {f"env['DRONA_WF_ID'] = '{drona_job_id}'" if drona_job_id else ""}
-        {f"env['DRONA_WF_DIR'] = '{job_location}'" if job_location else ""}
-        {f"env['DRONA_RUNTIME_DIR'] = '{runtime_dir}'" if runtime_dir else ""}
-        {f"env['DRONA_ENV_DIR'] = '{env_dir}'" if env_dir else ""}
-        {f"env['DRONA_ENV_NAME'] = '{env_name}'" if env_name else ""}
+        {f"env['DRONA_WF_ID'] = {drona_job_id!r}" if drona_job_id else ""}
+        {f"env['DRONA_WF_DIR'] = {job_location!r}" if job_location else ""}
+        {f"env['DRONA_RUNTIME_DIR'] = {runtime_dir!r}" if runtime_dir else ""}
+        {f"env['DRONA_ENV_DIR'] = {env_dir!r}" if env_dir else ""}
+        {f"env['DRONA_ENV_NAME'] = {env_name!r}" if env_name else ""}
 
 
         

--- a/views/utils.py
+++ b/views/utils.py
@@ -19,24 +19,38 @@ def create_folder_if_not_exist(dir_path):
         
 def _read_config_json():
     if not CONFIG_FILE.exists():
-        return {"ok": False, "reason": f"Config file not found: {CONFIG_FILE}"}
+        return {
+            "ok": False,
+            "error": "not_found",
+            "reason": f"Config file not found: {CONFIG_FILE}",
+        }
     try:
         cfg = json.loads(CONFIG_FILE.read_text())
         if not isinstance(cfg, dict):
-            return {"ok": False, "reason": "Config file must be a JSON object."}
+            return {"ok": False, "error": "invalid", "reason": "Config file must be a JSON object."}
 
-        dd = cfg.get("drona_dir", "")
-        if not isinstance(dd, str) or not dd.strip():
-            return {"ok": False, "reason": "Config missing 'drona_dir' key."}
+        dd = cfg.get("drona_dir")
+        if dd is None or (isinstance(dd, str) and not dd.strip()):
+            return {
+                "ok": False,
+                "error": "selection_required",
+                "reason": "Config is missing a usable 'drona_dir'. Please choose a new location.",
+            }
+        if not isinstance(dd, str):
+            return {"ok": False, "error": "invalid", "reason": "Config 'drona_dir' must be a string."}
 
         # Keep the raw path for comparison (so we can distinguish drona_wfe vs drona_composer)
         raw_path = Path(dd).expanduser()
 
         resolved = raw_path.resolve()
         if not raw_path.exists():
-            return {"ok": False, "reason": f"drona_dir does not exist: {raw_path}"}
+            return {
+                "ok": False,
+                "error": "selection_required",
+                "reason": f"Configured Drona directory no longer exists: {raw_path}. Please choose a new location.",
+            }
         if not resolved.is_dir():
-            return {"ok": False, "reason": f"drona_dir is not a directory: {resolved}"}
+            return {"ok": False, "error": "invalid", "reason": f"drona_dir is not a directory: {resolved}"}
             
         # IMPORTANT: return the raw path, not the resolved one
         return {
@@ -46,9 +60,9 @@ def _read_config_json():
             "drona_dir_resolved": str(resolved),  # e.g. "/scratch/.../drona_composer"
         }
     except json.JSONDecodeError:
-        return {"ok": False, "reason": "Config file is invalid JSON."}
+        return {"ok": False, "error": "invalid", "reason": "Config file is invalid JSON."}
     except Exception as e:
-        return {"ok": False, "reason": f"Failed to read config: {e}"}
+        return {"ok": False, "error": "unreadable", "reason": f"Failed to read config: {e}"}
 
         
 def _write_config_json_atomically(drona_dir_abs: str):
@@ -63,6 +77,28 @@ def _safe_rename(src: Path, dst: Path):
         os.replace(src, dst)  # atomic if same fs
     except OSError:
         shutil.move(str(src), str(dst))
+
+
+def _ensure_legacy_symlink(legacy_dir: Path, target: Path):
+    """Create the legacy alias, or verify an existing alias is exactly correct."""
+    try:
+        target.symlink_to(legacy_dir, target_is_directory=True)
+    except FileExistsError:
+        if not target.is_symlink():
+            raise RuntimeError(
+                f"Cannot migrate because '{target}' already exists and is not a symlink."
+            )
+
+        if not target.exists():
+            raise RuntimeError(
+                f"Cannot migrate because '{target}' is a broken symlink."
+            )
+
+        if target.resolve() != legacy_dir.resolve():
+            raise RuntimeError(
+                f"Cannot migrate because '{target}' points to '{target.resolve()}', "
+                f"not '{legacy_dir.resolve()}'."
+            )
         
 def probe_and_autofix_config():
     """
@@ -89,13 +125,26 @@ def probe_and_autofix_config():
             "action": "ok",
         }
 
+    if r.get("error") == "selection_required":
+        return {
+            "ok": False,
+            "reason": r.get("reason", "Please choose a Drona directory."),
+            "action": "select_needed",
+        }
+
+    # An existing config belongs to the user. Never replace it merely because it
+    # is malformed, unreadable, or temporarily points at unavailable storage.
+    if r.get("error") != "not_found":
+        return {
+            "ok": False,
+            "reason": r.get("reason", "Config is invalid."),
+            "action": "error",
+        }
+
     # 2) No valid config: if legacy dir exists, migrate
     if dc.is_dir():
         try:
-            try:
-                os.symlink(dc, target)
-            except FileExistsError:
-                pass  # already exists (could be symlink or real dir)
+            _ensure_legacy_symlink(dc, target)
 
             _write_config_json_atomically(str(target))
             return {
@@ -197,6 +246,12 @@ def get_drona_dir():
     if not cfg.get("ok"):
         return {"ok": False, "reason": cfg.get("reason", "Unknown error")}
     return {"ok": True, "drona_dir": cfg["drona_dir"]}
+
+
+def get_current_drona_dir():
+    """Return the current configured directory, or None when unavailable."""
+    drona = get_drona_dir()
+    return drona.get("drona_dir") if drona.get("ok") else None
 
 def get_envs_dir():
     g = get_drona_dir()


### PR DESCRIPTION
  - block job composer until directory configuration is valid
  - refresh configured paths without requiring repeated Passenger restarts
  - create or reuse drona_wfe without producing nested directories
  - recover when configured directories are removed
  - preserve invalid configs instead of silently overwriting them
  - validate legacy migration symlinks and writable destinations
  - support spaces and quotes in job and workflow paths
  - reload after legacy migration to prevent null run locations
  - improve directory picker instructions and error messages